### PR TITLE
Fix azurerm provider version upper limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.6, < 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.6, <= 3.114.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.6)
 
 - <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
 

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -64,7 +64,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.6, < 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.6, <= 3.114.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.6)
 
 ## Resources
 

--- a/examples/default/terraform.tf
+++ b/examples/default/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.6, <= 3.114.0"
+      version = "~> 3.6"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,7 @@ resource "azurerm_private_dns_zone" "this" {
   # create the soa_record block only if the var.soa_record is not empty
   dynamic "soa_record" {
     for_each = var.soa_record != null ? [1] : []
+
     content {
       email        = var.soa_record.email
       expire_time  = var.soa_record.expire_time
@@ -87,6 +88,7 @@ resource "azurerm_private_dns_mx_record" "this" {
 
   dynamic "record" {
     for_each = each.value.records
+
     content {
       exchange   = record.value.exchange
       preference = record.value.preference
@@ -120,6 +122,7 @@ resource "azurerm_private_dns_srv_record" "this" {
 
   dynamic "record" {
     for_each = each.value.records
+
     content {
       port     = record.value.port
       priority = record.value.priority
@@ -143,6 +146,7 @@ resource "azurerm_private_dns_txt_record" "this" {
 
   dynamic "record" {
     for_each = each.value.records
+
     content {
       value = record.value.value
     }

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.6, <= 3.114.0"
+      version = "~> 3.6"
     }
     modtm = {
       source  = "azure/modtm"


### PR DESCRIPTION
## Description

I wasn't able to use the module, because of the version restriction for the azurerm provider to <= 3.114.0, while I was using a later version 3.116.0. So I updated the version constrain in the same pattern as in them avm template, to allow any version of 3.x above 3.6.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
