### PR TITLE
feat: add timeouts for DNS zones and vNet Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,43 @@ Type: `map(string)`
 
 Default: `null`
 
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: A map of timeouts objects, per resource type, to apply to the creation and destruction of resources the following resources:
+
+- `dns_zones` - (Optional) The timeouts for DNS Zones.
+- `vnet_links` - (Optional) The timeouts for DNS Zones Virtual Network Links.
+
+Each timeout object has the following optional attributes:
+
+- `create` - (Optional) The timeout for creating the resource. Defaults to `5m` apart from policy assignments, where this is set to `15m`.
+- `delete` - (Optional) The timeout for deleting the resource. Defaults to `5m`.
+- `update` - (Optional) The timeout for updating the resource. Defaults to `5m`.
+- `read` - (Optional) The timeout for reading the resource. Defaults to `5m`.
+
+Type:
+
+```hcl
+object({
+    dns_zones = optional(object({
+      create = optional(string, "30m")
+      delete = optional(string, "30m")
+      update = optional(string, "30m")
+      read   = optional(string, "5m")
+      }), {}
+    )
+    vnet_links = optional(object({
+      create = optional(string, "30m")
+      delete = optional(string, "30m")
+      update = optional(string, "30m")
+      read   = optional(string, "5m")
+      }), {}
+    )
+  })
+```
+
+Default: `{}`
+
 ### <a name="input_txt_records"></a> [txt\_records](#input\_txt\_records)
 
 Description: A map of objects where each object contains information to create a TXT record.

--- a/avm.tflint_module.hcl
+++ b/avm.tflint_module.hcl
@@ -1,12 +1,12 @@
 plugin "terraform" {
   enabled = true
-  version = "0.5.0"
+  version = "0.10.0"
   source  = "github.com/terraform-linters/tflint-ruleset-terraform"
 }
 
 plugin "avm" {
   enabled     = true
-  version     = "0.11.1"
+  version     = "0.13.0"
   source      = "github.com/Azure/tflint-ruleset-avm"
   signing_key = <<-KEY
 -----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -190,4 +190,8 @@ rule "tags" {
 
 rule "provider_modtm_version" {
   enabled = false
+}
+
+rule "valid_template_interpolation" {
+  enabled = true
 }

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -64,7 +64,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.6, < 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.0, < 5.0)
 
 ## Resources
 

--- a/examples/default/terraform.tf
+++ b/examples/default/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116.0, < 5.0"
+      version = ">= 4.0, < 5.0"
     }
   }
 }

--- a/examples/timeouts/README.md
+++ b/examples/timeouts/README.md
@@ -26,8 +26,6 @@ provider "azurerm" {
   }
 }
 
-data "azurerm_client_config" "current" {}
-
 module "regions" {
   source  = "Azure/regions/azurerm"
   version = "~> 0.3"
@@ -109,7 +107,6 @@ The following resources are used by this module:
 - [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
 - [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) (resource)
 - [random_integer.region_index](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) (resource)
-- [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs

--- a/examples/timeouts/README.md
+++ b/examples/timeouts/README.md
@@ -1,0 +1,189 @@
+<!-- BEGIN_TF_DOCS -->
+# Default with timeouts example
+
+This deploys the module in its simplest form with the addition of custom timeouts.
+
+```hcl
+terraform {
+  required_version = "~> 1.5"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.0, < 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+module "regions" {
+  source  = "Azure/regions/azurerm"
+  version = "~> 0.3"
+}
+
+resource "random_integer" "region_index" {
+  max = length(module.regions.regions) - 1
+  min = 0
+}
+
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "~> 0.3"
+}
+
+resource "azurerm_resource_group" "this" {
+  location = module.regions.regions[random_integer.region_index.result].name
+  name     = module.naming.resource_group.name_unique
+}
+
+resource "azurerm_virtual_network" "this" {
+  address_space       = ["10.0.1.0/24"]
+  location            = azurerm_resource_group.this.location
+  name                = "vnet1"
+  resource_group_name = azurerm_resource_group.this.name
+}
+
+# reference the module and pass in variables as needed
+module "private_dns_zones" {
+  # replace source with the correct link to the private_dns_zones module
+  # source                = "Azure/avm-res-network-privatednszone/azurerm"  
+  source                = "../../"
+  enable_telemetry      = local.enable_telemetry
+  resource_group_name   = azurerm_resource_group.this.name
+  domain_name           = local.domain_name
+  tags                  = local.tags
+  soa_record            = local.soa_record
+  virtual_network_links = local.virtual_network_links
+  a_records             = local.a_records
+  aaaa_records          = local.aaaa_records
+  cname_records         = local.cname_records
+  mx_records            = local.mx_records
+  ptr_records           = local.ptr_records
+  srv_records           = local.srv_records
+  txt_records           = local.txt_records
+
+  timeouts = {
+    dns_zones = {
+      create = "50m"
+      delete = "50m"
+      read   = "10m"
+      update = "50m"
+    }
+    vnet_links = {
+      create = "50m"
+      delete = "50m"
+      read   = "10m"
+      update = "50m"
+    }
+  }
+}
+```
+
+<!-- markdownlint-disable MD033 -->
+## Requirements
+
+The following requirements are needed by this module:
+
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.0, < 5.0)
+
+- <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
+
+## Resources
+
+The following resources are used by this module:
+
+- [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
+- [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) (resource)
+- [random_integer.region_index](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) (resource)
+- [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
+
+<!-- markdownlint-disable MD013 -->
+## Required Inputs
+
+No required inputs.
+
+## Optional Inputs
+
+No optional inputs.
+
+## Outputs
+
+The following outputs are exported:
+
+### <a name="output_a_record_outputs"></a> [a\_record\_outputs](#output\_a\_record\_outputs)
+
+Description: The a record output
+
+### <a name="output_aaaa_record_outputs"></a> [aaaa\_record\_outputs](#output\_aaaa\_record\_outputs)
+
+Description: The aaaa record output
+
+### <a name="output_cname_record_outputs"></a> [cname\_record\_outputs](#output\_cname\_record\_outputs)
+
+Description: The cname record output
+
+### <a name="output_mx_record_outputs"></a> [mx\_record\_outputs](#output\_mx\_record\_outputs)
+
+Description: The mx record output
+
+### <a name="output_private_dns_zone_output"></a> [private\_dns\_zone\_output](#output\_private\_dns\_zone\_output)
+
+Description: The private dns zone output
+
+### <a name="output_ptr_record_outputs"></a> [ptr\_record\_outputs](#output\_ptr\_record\_outputs)
+
+Description: The ptr record output
+
+### <a name="output_srv_record_outputs"></a> [srv\_record\_outputs](#output\_srv\_record\_outputs)
+
+Description: The srv record output
+
+### <a name="output_txt_record_outputs"></a> [txt\_record\_outputs](#output\_txt\_record\_outputs)
+
+Description: The txt record output
+
+### <a name="output_virtual_network_link_outputs"></a> [virtual\_network\_link\_outputs](#output\_virtual\_network\_link\_outputs)
+
+Description: The virtual network link output
+
+## Modules
+
+The following Modules are called:
+
+### <a name="module_naming"></a> [naming](#module\_naming)
+
+Source: Azure/naming/azurerm
+
+Version: ~> 0.3
+
+### <a name="module_private_dns_zones"></a> [private\_dns\_zones](#module\_private\_dns\_zones)
+
+Source: ../../
+
+Version:
+
+### <a name="module_regions"></a> [regions](#module\_regions)
+
+Source: Azure/regions/azurerm
+
+Version: ~> 0.3
+
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.
+<!-- END_TF_DOCS -->

--- a/examples/timeouts/_footer.md
+++ b/examples/timeouts/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/examples/timeouts/_header.md
+++ b/examples/timeouts/_header.md
@@ -1,0 +1,3 @@
+# Default with timeouts example
+
+This deploys the module in its simplest form with the addition of custom timeouts.

--- a/examples/timeouts/locals.tf
+++ b/examples/timeouts/locals.tf
@@ -1,0 +1,240 @@
+locals {
+  a_records = {
+    "a_record1" = {
+      name                = "my_arecord1"
+      resource_group_name = "avmrg"
+      zone_name           = "testlab.io"
+      ttl                 = 300
+      records             = ["10.1.1.1", "10.1.1.2"]
+      tags = {
+        "env" = "prod"
+      }
+    }
+
+    "a_record2" = {
+      name                = "my_arecord2"
+      resource_group_name = "avmrg"
+      zone_name           = "testlab.io"
+      ttl                 = 300
+      records             = ["10.2.1.1", "10.2.1.2"]
+      tags = {
+        "env" = "dev"
+      }
+    }
+  }
+  aaaa_records = {
+    "aaaa_record1" = {
+      name                = "my_aaaarecord1"
+      resource_group_name = "avmrg"
+      zone_name           = "testlab.io"
+      ttl                 = 300
+      records             = ["fd5d:70bc:930e:d008:0000:0000:0000:7334", "fd5d:70bc:930e:d008::7335"]
+      tags = {
+        "env" = "prod"
+      }
+    }
+
+    "aaaa_record2" = {
+      name                = "my_aaaarecord2"
+      resource_group_name = "avmrg"
+      zone_name           = "testlab.io"
+      ttl                 = 600
+      records             = ["fd4d:70bc:930e:d008:0000:0000:0000:7334", "fd4d:70bc:930e:d008::7335"]
+      tags = {
+        "env" = "dev"
+      }
+    }
+  }
+  cname_records = {
+    "cname_record1" = {
+      name                = "my_cname1"
+      resource_group_name = "avmrg"
+      zone_name           = "testlab.io"
+      ttl                 = 300
+      record              = "prod.testlab.io"
+      tags = {
+        "env" = "prod"
+      }
+    }
+
+    "cname_record2" = {
+      name                = "my_cname2"
+      resource_group_name = "avmrg"
+      zone_name           = "testlab.io"
+      ttl                 = 300
+      record              = "dev.testlab.io"
+      tags = {
+        "env" = "dev"
+      }
+    }
+  }
+  domain_name      = "testlab.io"
+  enable_telemetry = false
+  mx_records = {
+    "mx_record1" = {
+      resource_group_name = "avmrg"
+      zone_name           = "testlab.io"
+      ttl                 = 300
+      records = {
+        "record1" = {
+          preference = 10
+          exchange   = "mail1.testlab.io"
+        }
+        "record2" = {
+          preference = 20
+          exchange   = "mail2.testlab.io"
+        }
+      }
+      tags = {
+        "env" = "prod"
+      }
+    }
+
+    "msx_record2" = {
+      name                = "backupmail"
+      resource_group_name = "avmrg"
+      zone_name           = "testlab.io"
+      ttl                 = 300
+      records = {
+        "record3" = {
+          preference = 10
+          exchange   = "backupmail1.testlab.io"
+        }
+        "record4" = {
+          preference = 20
+          exchange   = "backupmail2.testlab.io"
+        }
+      }
+      tags = {
+        "env" = "dev"
+      }
+    }
+  }
+  ptr_records = {
+    "ptr_record1" = {
+      name                = "ptr1"
+      resource_group_name = "avmrg"
+      zone_name           = "testlab.io"
+      ttl                 = 300
+      records             = ["web1.testlab.io", "web2.testlab.io"]
+      tags = {
+        "env" = "prod"
+      }
+    }
+
+    "ptr_record2" = {
+      name                = "ptr2"
+      resource_group_name = "avmrg"
+      zone_name           = "testlab.io"
+      ttl                 = 300
+      records             = ["web1.testlab.io", "web2.testlab.io"]
+      tags = {
+        "env" = "dev"
+      }
+    }
+
+  }
+  soa_record = {
+    email = "hostmaster.${local.domain_name}"
+  }
+  srv_records = {
+    "srv_record1" = {
+      name                = "srv1"
+      resource_group_name = "avmrg"
+      zone_name           = "testlab.io"
+      ttl                 = 300
+      records = {
+        "srvrecordA" = {
+          priority = 1
+          weight   = 5
+          port     = 8080
+          target   = "targetA.testlab.io"
+        }
+        "srvrecordB" = {
+          priority = 2
+          weight   = 5
+          port     = 8080
+          target   = "targetB.testlab.io"
+        }
+      }
+      tags = {
+        "env" = "prod"
+      }
+    }
+
+    "srv_record2" = {
+      name                = "srv2"
+      resource_group_name = "avmrg"
+      zone_name           = "testlab.io"
+      ttl                 = 300
+      records = {
+        "srvrecordC" = {
+          priority = 3
+          weight   = 5
+          port     = 8080
+          target   = "targetC.testlab.io"
+        }
+        "srvrecordD" = {
+          priority = 4
+          weight   = 5
+          port     = 8080
+          target   = "targetD.testlab.io"
+        }
+      }
+      tags = {
+        "env" = "dev"
+      }
+    }
+  }
+  tags = {
+    environment = "test"
+  }
+  txt_records = {
+    "txt_record1" = {
+      name                = "txt1"
+      resource_group_name = "avmrg"
+      zone_name           = "testlab.io"
+      ttl                 = 300
+      records = {
+        "txtrecordA" = {
+          value = "apple"
+        }
+        "txtrecordB" = {
+          value = "banana"
+        }
+      }
+      tags = {
+        "env" = "prod"
+      }
+    }
+
+    "txt_record2" = {
+      name                = "txt2"
+      resource_group_name = "avmrg"
+      zone_name           = "testlab.io"
+      ttl                 = 300
+      records = {
+        "txtrecordC" = {
+          value = "orange"
+        }
+        "txtrecordD" = {
+          value = "durian"
+        }
+      }
+      tags = {
+        "env" = "prod"
+      }
+    }
+
+  }
+  virtual_network_links = {
+    vnetlink1 = {
+      vnetlinkname     = "vnetlink1"
+      vnetid           = azurerm_virtual_network.this.id
+      autoregistration = true
+      tags = {
+        "env" = "prod"
+      }
+    }
+  }
+}

--- a/examples/timeouts/main.tf
+++ b/examples/timeouts/main.tf
@@ -1,0 +1,85 @@
+terraform {
+  required_version = "~> 1.5"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.0, < 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+module "regions" {
+  source  = "Azure/regions/azurerm"
+  version = "~> 0.3"
+}
+
+resource "random_integer" "region_index" {
+  max = length(module.regions.regions) - 1
+  min = 0
+}
+
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "~> 0.3"
+}
+
+resource "azurerm_resource_group" "this" {
+  location = module.regions.regions[random_integer.region_index.result].name
+  name     = module.naming.resource_group.name_unique
+}
+
+resource "azurerm_virtual_network" "this" {
+  address_space       = ["10.0.1.0/24"]
+  location            = azurerm_resource_group.this.location
+  name                = "vnet1"
+  resource_group_name = azurerm_resource_group.this.name
+}
+
+# reference the module and pass in variables as needed
+module "private_dns_zones" {
+  # replace source with the correct link to the private_dns_zones module
+  # source                = "Azure/avm-res-network-privatednszone/azurerm"  
+  source                = "../../"
+  enable_telemetry      = local.enable_telemetry
+  resource_group_name   = azurerm_resource_group.this.name
+  domain_name           = local.domain_name
+  tags                  = local.tags
+  soa_record            = local.soa_record
+  virtual_network_links = local.virtual_network_links
+  a_records             = local.a_records
+  aaaa_records          = local.aaaa_records
+  cname_records         = local.cname_records
+  mx_records            = local.mx_records
+  ptr_records           = local.ptr_records
+  srv_records           = local.srv_records
+  txt_records           = local.txt_records
+
+  timeouts = {
+    dns_zones = {
+      create = "50m"
+      delete = "50m"
+      read   = "10m"
+      update = "50m"
+    }
+    vnet_links = {
+      create = "50m"
+      delete = "50m"
+      read   = "10m"
+      update = "50m"
+    }
+  }
+}

--- a/examples/timeouts/main.tf
+++ b/examples/timeouts/main.tf
@@ -20,8 +20,6 @@ provider "azurerm" {
   }
 }
 
-data "azurerm_client_config" "current" {}
-
 module "regions" {
   source  = "Azure/regions/azurerm"
   version = "~> 0.3"

--- a/examples/timeouts/outputs.tf
+++ b/examples/timeouts/outputs.tf
@@ -1,0 +1,44 @@
+output "a_record_outputs" {
+  description = "The a record output"
+  value       = module.private_dns_zones.a_record_outputs
+}
+
+output "aaaa_record_outputs" {
+  description = "The aaaa record output"
+  value       = module.private_dns_zones.aaaa_record_outputs
+}
+
+output "cname_record_outputs" {
+  description = "The cname record output"
+  value       = module.private_dns_zones.cname_record_outputs
+}
+
+output "mx_record_outputs" {
+  description = "The mx record output"
+  value       = module.private_dns_zones.mx_record_outputs
+}
+
+output "private_dns_zone_output" {
+  description = "The private dns zone output"
+  value       = module.private_dns_zones.resource
+}
+
+output "ptr_record_outputs" {
+  description = "The ptr record output"
+  value       = module.private_dns_zones.ptr_record_outputs
+}
+
+output "srv_record_outputs" {
+  description = "The srv record output"
+  value       = module.private_dns_zones.srv_record_outputs
+}
+
+output "txt_record_outputs" {
+  description = "The txt record output"
+  value       = module.private_dns_zones.txt_record_outputs
+}
+
+output "virtual_network_link_outputs" {
+  description = "The virtual network link output"
+  value       = module.private_dns_zones.virtual_network_link_outputs
+}

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,5 @@
-# TODO: insert resources here.
-# resource "azurerm_resource_group" "this" {
-#   name     = var.resource_group_name
-#   location = var.resource_group_location
-# }
-
 resource "azurerm_private_dns_zone" "this" {
-  name = var.domain_name
-  #   resource_group_name = azurerm_resource_group.this.name
+  name                = var.domain_name
   resource_group_name = var.resource_group_name
   tags                = var.tags
 
@@ -23,8 +16,13 @@ resource "azurerm_private_dns_zone" "this" {
       ttl          = var.soa_record.ttl
     }
   }
+  timeouts {
+    create = var.timeouts.dns_zones.create
+    delete = var.timeouts.dns_zones.delete
+    read   = var.timeouts.dns_zones.read
+    update = var.timeouts.dns_zones.update
+  }
 }
-
 
 resource "azurerm_private_dns_zone_virtual_network_link" "this" {
   for_each = var.virtual_network_links
@@ -35,6 +33,13 @@ resource "azurerm_private_dns_zone_virtual_network_link" "this" {
   virtual_network_id    = each.value.vnetid
   registration_enabled  = lookup(each.value, "autoregistration", false)
   tags                  = lookup(each.value, "tags", null)
+
+  timeouts {
+    create = var.timeouts.vnet_links.create
+    delete = var.timeouts.vnet_links.delete
+    read   = var.timeouts.vnet_links.read
+    update = var.timeouts.vnet_links.update
+  }
 }
 
 resource "azurerm_private_dns_a_record" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -125,6 +125,40 @@ variable "tags" {
   description = "(Optional) Tags of the resource."
 }
 
+variable "timeouts" {
+  type = object({
+    dns_zones = optional(object({
+      create = optional(string, "30m")
+      delete = optional(string, "30m")
+      update = optional(string, "30m")
+      read   = optional(string, "5m")
+      }), {}
+    )
+    vnet_links = optional(object({
+      create = optional(string, "30m")
+      delete = optional(string, "30m")
+      update = optional(string, "30m")
+      read   = optional(string, "5m")
+      }), {}
+    )
+  })
+  default     = {}
+  description = <<DESCRIPTION
+A map of timeouts objects, per resource type, to apply to the creation and destruction of resources the following resources:
+
+- `dns_zones` - (Optional) The timeouts for DNS Zones.
+- `vnet_links` - (Optional) The timeouts for DNS Zones Virtual Network Links.
+
+Each timeout object has the following optional attributes:
+
+- `create` - (Optional) The timeout for creating the resource. Defaults to `5m` apart from policy assignments, where this is set to `15m`.
+- `delete` - (Optional) The timeout for deleting the resource. Defaults to `5m`.
+- `update` - (Optional) The timeout for updating the resource. Defaults to `5m`.
+- `read` - (Optional) The timeout for reading the resource. Defaults to `5m`.
+
+DESCRIPTION
+}
+
 variable "txt_records" {
   type = map(object({
     name                = string


### PR DESCRIPTION
## Description

feat: add timeouts for DNS zones and vNet Links

Related to https://github.com/Azure/terraform-azurerm-avm-ptn-network-private-link-private-dns-zones/issues/64#issuecomment-2617115857


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
