### PR TITLE
Corrected virtual network link azapi resource symbolic name

### DIFF
--- a/examples/resolutionpolicy/README.md
+++ b/examples/resolutionpolicy/README.md
@@ -46,8 +46,8 @@ module "vnet" {
 }
 
 # reference the module and pass in variables as needed
-module "private_link_dns_zone" {
-  # replace source with the correct link to the private_link_dns_zone module
+module "private_dns_zone" {
+  # replace source with the correct link to the private_dns_zone module
   # source                = "Azure/avm-res-network-privatednszone/azurerm"
   source = "../../"
 
@@ -70,7 +70,7 @@ module "avm_storageaccount" {
       name                          = module.naming.private_endpoint.name_unique
       subnet_resource_id            = module.vnet.subnets["subnet1"].resource_id
       subresource_name              = "blob"
-      private_dns_zone_resource_ids = [module.private_link_dns_zone.resource_id]
+      private_dns_zone_resource_ids = [module.private_dns_zone.resource_id]
     }
   }
   role_assignments = {
@@ -138,7 +138,7 @@ Source: Azure/naming/azurerm
 
 Version: >= 0.3.0
 
-### <a name="module_private_link_dns_zone"></a> [private\_link\_dns\_zone](#module\_private\_link\_dns\_zone)
+### <a name="module_private_dns_zone"></a> [private\_dns\_zone](#module\_private\_dns\_zone)
 
 Source: ../../
 

--- a/examples/resolutionpolicy/main.tf
+++ b/examples/resolutionpolicy/main.tf
@@ -40,8 +40,8 @@ module "vnet" {
 }
 
 # reference the module and pass in variables as needed
-module "private_link_dns_zone" {
-  # replace source with the correct link to the private_link_dns_zone module
+module "private_dns_zone" {
+  # replace source with the correct link to the private_dns_zone module
   # source                = "Azure/avm-res-network-privatednszone/azurerm"
   source = "../../"
 
@@ -64,7 +64,7 @@ module "avm_storageaccount" {
       name                          = module.naming.private_endpoint.name_unique
       subnet_resource_id            = module.vnet.subnets["subnet1"].resource_id
       subresource_name              = "blob"
-      private_dns_zone_resource_ids = [module.private_link_dns_zone.resource_id]
+      private_dns_zone_resource_ids = [module.private_dns_zone.resource_id]
     }
   }
   role_assignments = {

--- a/examples/resolutionpolicy/outputs.tf
+++ b/examples/resolutionpolicy/outputs.tf
@@ -1,9 +1,9 @@
 output "private_dns_zone_output" {
   description = "The private dns zone output"
-  value       = module.private_link_dns_zone.resource
+  value       = module.private_dns_zone.resource
 }
 
 output "virtual_network_link_outputs" {
   description = "The virtual network link output"
-  value       = module.private_link_dns_zone.virtual_network_link_outputs
+  value       = module.private_dns_zone.virtual_network_link_outputs
 }

--- a/modules/private_dns_virtual_network_link/README.md
+++ b/modules/private_dns_virtual_network_link/README.md
@@ -68,7 +68,7 @@ The following requirements are needed by this module:
 
 The following resources are used by this module:
 
-- [azapi_resource.private_link_zone_network_link](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.private_dns_zone_network_link](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs

--- a/modules/private_dns_virtual_network_link/main.tf
+++ b/modules/private_dns_virtual_network_link/main.tf
@@ -1,4 +1,4 @@
-resource "azapi_resource" "private_link_zone_network_link" {
+resource "azapi_resource" "private_dns_zone_network_link" {
   location  = "global"
   name      = var.name
   parent_id = var.parent_id

--- a/modules/private_dns_virtual_network_link/outputs.tf
+++ b/modules/private_dns_virtual_network_link/outputs.tf
@@ -1,9 +1,9 @@
 output "resource" {
   description = "The outputs of the virtual network link resource."
-  value       = azapi_resource.private_link_zone_network_link.output
+  value       = azapi_resource.private_dns_zone_network_link.output
 }
 
 output "resource_id" {
   description = "The resource ID of the created virtual network link."
-  value       = azapi_resource.private_link_zone_network_link.id
+  value       = azapi_resource.private_dns_zone_network_link.id
 }


### PR DESCRIPTION
## Description

<!--
 This PR is meant to fix a name discrepancy with the symbolic name used within a submodule for virtual network links and the root module.
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
