### PR TITLE
feat!: use random uuid for role assignment name

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,21 @@ object({
 
 Default: `{}`
 
+### <a name="input_role_assignment_name_use_random_uuid"></a> [role\_assignment\_name\_use\_random\_uuid](#input\_role\_assignment\_name\_use\_random\_uuid)
+
+Description: A control to use a random UUID for the role assignment name.  
+If set to false, the name will be a deterministic UUID based on the principal ID and role definition resource ID,  
+though this can cause issues with duplicate UUIDs as the scope of the role assignment is not taken into account.
+
+We recommend this is set to true to avoid resources becoming re-created due to computed attribute changes in the resource graph, however it can be set to false to preserve legacy behaviour.
+
+When this is set to true, you must not change the principal or role definition values in the `role_assignments` map after the initial creation of the role assignments as this will cause errors.  
+Instead, use a new key in the map with the new values and remove the old entry.
+
+Type: `bool`
+
+Default: `true`
+
 ### <a name="input_role_assignments"></a> [role\_assignments](#input\_role\_assignments)
 
 Description:   A map of role assignments to create on the <RESOURCE>. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
@@ -463,7 +478,7 @@ Version:
 
 Source: Azure/avm-utl-interfaces/azure
 
-Version: 0.2.0
+Version: 0.5.0
 
 ### <a name="module_cname_record"></a> [cname\_record](#module\_cname\_record)
 

--- a/main.tf
+++ b/main.tf
@@ -155,12 +155,13 @@ module "txt_record" {
 
 module "avm_interfaces" {
   source  = "Azure/avm-utl-interfaces/azure"
-  version = "0.2.0"
+  version = "0.5.0"
 
   enable_telemetry                          = var.enable_telemetry
   lock                                      = var.lock
   role_assignment_definition_lookup_enabled = true
   role_assignment_definition_scope          = var.parent_id
+  role_assignment_name_use_random_uuid      = var.role_assignment_name_use_random_uuid
   role_assignments                          = var.role_assignments
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -298,3 +298,19 @@ variable "virtual_network_links" {
     error_message = "Each virtual network link name must have less than 80 characters."
   }
 }
+
+variable "role_assignment_name_use_random_uuid" {
+  type        = bool
+  default     = true
+  description = <<DESCRIPTION
+A control to use a random UUID for the role assignment name.
+If set to false, the name will be a deterministic UUID based on the principal ID and role definition resource ID,
+though this can cause issues with duplicate UUIDs as the scope of the role assignment is not taken into account.
+
+We recommend this is set to true to avoid resources becoming re-created due to computed attribute changes in the resource graph, however it can be set to false to preserve legacy behaviour.
+
+When this is set to true, you must not change the principal or role definition values in the `role_assignments` map after the initial creation of the role assignments as this will cause errors.
+Instead, use a new key in the map with the new values and remove the old entry.
+DESCRIPTION
+  nullable    = false
+}


### PR DESCRIPTION
## Description
Defaults to using a random UUID for role assignment names to avoid duplicates, which are currently likely due to the current deterministic behavior which is based just on role definition and principal, and ignores the scope. 

Marking this as breaking change as it will cause existing role assignments to be re-created, however existing behavior can be maintained by setting the new variable `role_assignment_name_use_random_uuid` to false. 

Closes #129

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [X] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [X] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
