### PR TITLE
fix: remove deprecated multiplier attribute from retry variable

### DIFF
--- a/modules/private_dns_a_record/variables.tf
+++ b/modules/private_dns_a_record/variables.tf
@@ -47,7 +47,6 @@ variable "retry" {
     error_message_regex  = optional(list(string), ["ReferencedResourceNotProvisioned", "CannotDeleteResource"])
     interval_seconds     = optional(number, 10)
     max_interval_seconds = optional(number, 180)
-    multiplier           = optional(number, 1.5)
     randomization_factor = optional(number, 0.5)
   })
   default     = {}

--- a/modules/private_dns_a_record/variables.tf
+++ b/modules/private_dns_a_record/variables.tf
@@ -47,7 +47,6 @@ variable "retry" {
     error_message_regex  = optional(list(string), ["ReferencedResourceNotProvisioned", "CannotDeleteResource"])
     interval_seconds     = optional(number, 10)
     max_interval_seconds = optional(number, 180)
-    randomization_factor = optional(number, 0.5)
   })
   default     = {}
   description = "Retry configuration for the resource operations"

--- a/modules/private_dns_aaaa_record/variables.tf
+++ b/modules/private_dns_aaaa_record/variables.tf
@@ -42,7 +42,6 @@ variable "retry" {
     error_message_regex  = optional(list(string), ["ReferencedResourceNotProvisioned", "CannotDeleteResource"])
     interval_seconds     = optional(number, 10)
     max_interval_seconds = optional(number, 180)
-    multiplier           = optional(number, 1.5)
     randomization_factor = optional(number, 0.5)
   })
   default     = {}

--- a/modules/private_dns_aaaa_record/variables.tf
+++ b/modules/private_dns_aaaa_record/variables.tf
@@ -42,7 +42,6 @@ variable "retry" {
     error_message_regex  = optional(list(string), ["ReferencedResourceNotProvisioned", "CannotDeleteResource"])
     interval_seconds     = optional(number, 10)
     max_interval_seconds = optional(number, 180)
-    randomization_factor = optional(number, 0.5)
   })
   default     = {}
   description = "Retry configuration for the resource operations"

--- a/modules/private_dns_cname_record/variables.tf
+++ b/modules/private_dns_cname_record/variables.tf
@@ -53,7 +53,6 @@ variable "retry" {
     error_message_regex  = optional(list(string), ["ReferencedResourceNotProvisioned", "CannotDeleteResource"])
     interval_seconds     = optional(number, 10)
     max_interval_seconds = optional(number, 180)
-    multiplier           = optional(number, 1.5)
     randomization_factor = optional(number, 0.5)
   })
   default     = {}

--- a/modules/private_dns_cname_record/variables.tf
+++ b/modules/private_dns_cname_record/variables.tf
@@ -53,7 +53,6 @@ variable "retry" {
     error_message_regex  = optional(list(string), ["ReferencedResourceNotProvisioned", "CannotDeleteResource"])
     interval_seconds     = optional(number, 10)
     max_interval_seconds = optional(number, 180)
-    randomization_factor = optional(number, 0.5)
   })
   default     = {}
   description = "Retry configuration for the resource operations"

--- a/modules/private_dns_mx_record/variables.tf
+++ b/modules/private_dns_mx_record/variables.tf
@@ -50,7 +50,6 @@ variable "retry" {
     error_message_regex  = optional(list(string), ["ReferencedResourceNotProvisioned", "CannotDeleteResource"])
     interval_seconds     = optional(number, 10)
     max_interval_seconds = optional(number, 180)
-    multiplier           = optional(number, 1.5)
     randomization_factor = optional(number, 0.5)
   })
   default     = {}

--- a/modules/private_dns_mx_record/variables.tf
+++ b/modules/private_dns_mx_record/variables.tf
@@ -50,7 +50,6 @@ variable "retry" {
     error_message_regex  = optional(list(string), ["ReferencedResourceNotProvisioned", "CannotDeleteResource"])
     interval_seconds     = optional(number, 10)
     max_interval_seconds = optional(number, 180)
-    randomization_factor = optional(number, 0.5)
   })
   default     = {}
   description = "Retry configuration for the resource operations"

--- a/modules/private_dns_ptr_record/variables.tf
+++ b/modules/private_dns_ptr_record/variables.tf
@@ -47,7 +47,6 @@ variable "retry" {
     error_message_regex  = optional(list(string), ["ReferencedResourceNotProvisioned", "CannotDeleteResource"])
     interval_seconds     = optional(number, 10)
     max_interval_seconds = optional(number, 180)
-    multiplier           = optional(number, 1.5)
     randomization_factor = optional(number, 0.5)
   })
   default     = {}

--- a/modules/private_dns_ptr_record/variables.tf
+++ b/modules/private_dns_ptr_record/variables.tf
@@ -47,7 +47,6 @@ variable "retry" {
     error_message_regex  = optional(list(string), ["ReferencedResourceNotProvisioned", "CannotDeleteResource"])
     interval_seconds     = optional(number, 10)
     max_interval_seconds = optional(number, 180)
-    randomization_factor = optional(number, 0.5)
   })
   default     = {}
   description = "Retry configuration for the resource operations"

--- a/modules/private_dns_soa_record/variables.tf
+++ b/modules/private_dns_soa_record/variables.tf
@@ -87,7 +87,6 @@ variable "retry" {
     error_message_regex  = optional(list(string), ["ReferencedResourceNotProvisioned", "CannotDeleteResource"])
     interval_seconds     = optional(number, 10)
     max_interval_seconds = optional(number, 180)
-    multiplier           = optional(number, 1.5)
     randomization_factor = optional(number, 0.5)
   })
   default     = {}

--- a/modules/private_dns_soa_record/variables.tf
+++ b/modules/private_dns_soa_record/variables.tf
@@ -87,7 +87,6 @@ variable "retry" {
     error_message_regex  = optional(list(string), ["ReferencedResourceNotProvisioned", "CannotDeleteResource"])
     interval_seconds     = optional(number, 10)
     max_interval_seconds = optional(number, 180)
-    randomization_factor = optional(number, 0.5)
   })
   default     = {}
   description = "Retry configuration for the resource operations"

--- a/modules/private_dns_srv_record/variables.tf
+++ b/modules/private_dns_srv_record/variables.tf
@@ -52,7 +52,6 @@ variable "retry" {
     error_message_regex  = optional(list(string), ["ReferencedResourceNotProvisioned", "CannotDeleteResource"])
     interval_seconds     = optional(number, 10)
     max_interval_seconds = optional(number, 180)
-    multiplier           = optional(number, 1.5)
     randomization_factor = optional(number, 0.5)
   })
   default     = {}

--- a/modules/private_dns_srv_record/variables.tf
+++ b/modules/private_dns_srv_record/variables.tf
@@ -52,7 +52,6 @@ variable "retry" {
     error_message_regex  = optional(list(string), ["ReferencedResourceNotProvisioned", "CannotDeleteResource"])
     interval_seconds     = optional(number, 10)
     max_interval_seconds = optional(number, 180)
-    randomization_factor = optional(number, 0.5)
   })
   default     = {}
   description = "Retry configuration for the resource operations"

--- a/modules/private_dns_txt_record/variables.tf
+++ b/modules/private_dns_txt_record/variables.tf
@@ -49,7 +49,6 @@ variable "retry" {
     error_message_regex  = optional(list(string), ["ReferencedResourceNotProvisioned", "CannotDeleteResource"])
     interval_seconds     = optional(number, 10)
     max_interval_seconds = optional(number, 180)
-    randomization_factor = optional(number, 0.5)
   })
   default     = {}
   description = "Retry configuration for the resource operations"

--- a/modules/private_dns_txt_record/variables.tf
+++ b/modules/private_dns_txt_record/variables.tf
@@ -49,7 +49,6 @@ variable "retry" {
     error_message_regex  = optional(list(string), ["ReferencedResourceNotProvisioned", "CannotDeleteResource"])
     interval_seconds     = optional(number, 10)
     max_interval_seconds = optional(number, 180)
-    multiplier           = optional(number, 1.5)
     randomization_factor = optional(number, 0.5)
   })
   default     = {}

--- a/modules/private_dns_virtual_network_link/variables.tf
+++ b/modules/private_dns_virtual_network_link/variables.tf
@@ -64,7 +64,6 @@ variable "retry" {
     error_message_regex  = optional(list(string), ["ReferencedResourceNotProvisioned", "CannotDeleteResource"])
     interval_seconds     = optional(number, 10)
     max_interval_seconds = optional(number, 180)
-    multiplier           = optional(number, 1.5)
     randomization_factor = optional(number, 0.5)
   })
   default     = {}

--- a/modules/private_dns_virtual_network_link/variables.tf
+++ b/modules/private_dns_virtual_network_link/variables.tf
@@ -64,7 +64,6 @@ variable "retry" {
     error_message_regex  = optional(list(string), ["ReferencedResourceNotProvisioned", "CannotDeleteResource"])
     interval_seconds     = optional(number, 10)
     max_interval_seconds = optional(number, 180)
-    randomization_factor = optional(number, 0.5)
   })
   default     = {}
   description = "Retry configuration for the resource operations"

--- a/variables.tf
+++ b/variables.tf
@@ -137,7 +137,6 @@ variable "retry" {
     error_message_regex  = optional(list(string), ["ReferencedResourceNotProvisioned", "CannotDeleteResource"])
     interval_seconds     = optional(number, 10)
     max_interval_seconds = optional(number, 180)
-    randomization_factor = optional(number, 0.5)
   })
   default     = {}
   description = "Retry configuration for the resource operations"

--- a/variables.tf
+++ b/variables.tf
@@ -137,7 +137,6 @@ variable "retry" {
     error_message_regex  = optional(list(string), ["ReferencedResourceNotProvisioned", "CannotDeleteResource"])
     interval_seconds     = optional(number, 10)
     max_interval_seconds = optional(number, 180)
-    multiplier           = optional(number, 1.5)
     randomization_factor = optional(number, 0.5)
   })
   default     = {}


### PR DESCRIPTION
The azapi provider deprecated the `multiplier` attribute in the `retry` block. Remove it from the retry object type definition in the root module and all 9 submodules (a, aaaa, cname, mx, ptr, soa, srv, txt records and virtual network link).

## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ x ] Someone has opened a bug report issue, and I have included "Closes #133" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
