### PR TITLE
fix: use resource name in output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -44,7 +44,7 @@ output "mx_record_outputs" {
 
 output "name" {
   description = "The name of private DNS zone"
-  value       = azapi_resource.private_dns_zone.output.name
+  value       = azapi_resource.private_dns_zone.name
 }
 
 output "ptr_record_outputs" {


### PR DESCRIPTION
Use the AzAPI resource's `name` attribute so imports do not depend on the API response body.

CI: unit, integration, E2E, and CodeQL pass. Managed lint fails on pre-existing module-wide AVM compliance gaps.

Fixes #162